### PR TITLE
feat: Added parentHit in PageCallHit to track navigation flows,…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# 🧾 CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [1.1.0] – 2025-07-01
+
+> ⚠️ **This version needs to create a Doctrine migration**
+
+### ✨ Added
+- **Support for parentHit** in `PageCallHit`: you can now associate a hit with a parent hit to track navigation flows.
+- Error handling and validation for `/track` and `/exit` endpoints (invalid JSON, missing URL or hitId, etc.).
+- File `FEATURE_IDEAS.md` added to track suggestions and ideas.
+- File `CONTRIBUTING.md` added for contributors.
+- File `CHANGELOG.md` added.
+
+### 📦 Changed
+- Minor internal optimizations in the controller (reuse of `$em` instead of injecting repositories).
+
+---
+
+## [1.0.0] – 2025-06-28
+
+> ⚠️ **This version needs to create a Doctrine migration**
+
+### 🎉 Initial release
+- Symfony bundle with Stimulus-based page tracking.
+- Tracks: current URL, route, UTM params, language, screen size, entry/exit time.
+- GDPR-friendly: no cookies, no personal data.
+- Profiler integration to debug UTM parameters.
+- Async tracking via `fetch()` and exit detection.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# 🤝 Contributing to SeoTrackingBundle
+
+First off, thank you for considering contributing to this bundle! 🚀  
+Your ideas, fixes, and improvements help make the project better for everyone.
+
+---
+
+## 📋 Table of contents
+
+- [Code of conduct](#-code-of-conduct)
+- [How to contribute](#-how-to-contribute)
+- [Development setup](#-development-setup)
+- [Submitting a pull request](#-submitting-a-pull-request)
+- [Code style](#-code-style)
+- [Tests](#-tests)
+- [Feature ideas](#-feature-ideas)
+
+---
+
+## 📜 Code of conduct
+
+This project follows a simple rule:  
+**Be respectful, constructive, and kind.** 🙏
+
+---
+
+## 🛠️ How to contribute
+
+You can help in many ways:
+
+- 📥 Report bugs via [GitHub issues](../../issues)
+- 💡 Suggest features (see [`FEATURE_IDEAS.md`](./FEATURE_IDEAS.md))
+- 🧪 Write or improve tests
+- 🧼 Refactor code or improve performance
+- 📚 Improve documentation or add examples
+
+---
+
+## 💻 Development setup
+
+```bash
+# Clone the repository
+git clone https://github.com/zhortein/seo-tracking-bundle.git
+cd seo-tracking-bundle
+
+# Install dependencies
+make installdeps
+
+# Update dependencies
+make updatedeps
+
+# Run PHPStan
+make phpstan
+
+# Run CS Fixer
+make csfixer
+
+# Run the test suite
+make test 
+```
+
+## 🔀 Submitting a pull request
+1. Fork the repository
+2. Create your feature branch:
+```bash
+git checkout -b feature/my-awesome-change
+```
+3. Commit your changes (see below for style guidelines)
+4. Push to your branch and open a PR against `main`
+   
+Please include:
+* A clear description of what the PR does
+* Any related issue or feature request (use Fixes #xx)
+* Screenshots or examples if it's a visual/UI change
+
+## 🧹 Code style
+This bundle follows Symfony's coding standards.
+
+Before pushing your changes, please run:
+```bash
+make csfixer
+make phpstan
+```
+If any error is listed by PHPStan, please correct before pushing your changes !
+
+If you add Twig templates, make sure to follow:
+* [Symfony UX & Twig Best Practices](https://symfony.com/doc/current/templates.html)
+
+## ✅ Tests
+All new features or fixes must include relevant tests.
+Tests live in the tests/ directory and follow the PHPUnit naming convention.
+
+To run tests:
+```bash
+make test
+```
+
+## 🧠 Feature ideas
+Check the [FEATURE_IDEAS.md](./FEATURE_IDEAS.md) file for inspiration, open discussions, or things we plan to add later. 
+Feel free to open a PR to suggest one of them 🚀
+
+---- 
+
+Thank you again for your contribution! 🙌
+— The SeoTrackingBundle Maintainers

--- a/FEATURE_IDEAS.md
+++ b/FEATURE_IDEAS.md
@@ -1,0 +1,60 @@
+# ✨ Feature Ideas for SeoTrackingBundle
+
+This file lists potential improvements and optional features that could be added to the bundle in future versions.
+
+> 💡 Feel free to contribute or open issues if you have ideas or suggestions!
+
+---
+
+## ✅ Validated ideas to consider implementing
+
+### 1. Ignore bot traffic
+Skip tracking for known bots (Googlebot, Bingbot...) based on the User-Agent.
+```php
+if (preg_match('/bot|crawl|slurp|spider/i', $userAgent)) {
+    return new JsonResponse(['status' => 'ignored - bot']);
+}
+```
+
+### 2. Truncate long strings
+To avoid potential DB errors, truncate referer, userAgent, UTM values, etc. to a reasonable size (e.g. 255 or 512 chars).
+
+### 3. Sanitize input values
+Add a helper like:
+
+```php
+function sanitize(?string $value, int $maxLength = 255): ?string
+```
+Then use it for campaign, term, medium, etc.
+
+### 4. Rate limiting
+Add a [Symfony RateLimiter](https://symfony.com/doc/current/rate_limiter.html) to /page-call/track endpoint to prevent abuse or unexpected flood of requests.
+
+### 5. Extract tracking logic into a dedicated service `#refacto` `#priority-high`
+Move logic from controller into a PageCallTracker service to ease unit testing and future reuse.
+
+### 6. Add support for tracking errors or invalid events
+Allow logging or tracking of broken pages, 404s, or user misclicks via a custom endpoint.
+
+### 7. Add a CLI tool to clean old hits
+A Symfony Command to purge hits older than X months, or hits without exit timestamps.
+
+### 8. Add a lightweight dashboard or API
+Expose a simple admin route or API to visualize aggregated stats (nbCalls, exits, duration, referrers...).
+
+## ❓ Under consideration
+
+### 🔐 GDPR: add optional consent handling
+Require explicit frontend opt-in before tracking starts. Could integrate with existing cookie banner solutions.
+
+### 🧠 Enhanced visitor flow tracking
+Use parentHitId to build visit trees or paths. Consider how far this should go (e.g. depth limit, expiration, session-based grouping...).
+
+### 📦 Support PostgreSQL JSON for extra metrics
+Allow developers to store extra info (e.g. A/B test variation, user context...) in a JSON field.
+
+## 🚫 Rejected ideas (for now)
+(none yet)
+
+## 🗓️ Last update
+Generated on: 2025-07-01

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ If you're not using Symfony Flex, enable the bundle manually in config/bundles.p
 Zhortein\SeoTrackingBundle\SeoTrackingBundle::class => ['all' => true],
 ```
 
+## ⚠️ Database migration required!
+
+After installing the bundle, and sometimes upgrading the bundle (check the [CHANGELOG](./CHANGELOG.md)), you must run a migration to create the required database tables:
+```bash
+php bin/console make:migration
+php bin/console doctrine:migrations:migrate
+```
+If you're using custom naming strategies or a prefixed schema, review the generated migration before applying it.
+
 ## ⚙️ Usage
 To enable tracking, include the Stimulus controller in your layout or any page you want to track:
 
@@ -86,6 +95,9 @@ This entity stores information related to a visit (hit) and is related to a Page
 * language: navigator language (if provided by the navigator)
 * screenWidth: screen width in pixels (if provided by the navigator)
 * screenHeight: screen height in pixels (if provided by the navigator)
+* parentHit: previous PageCalledHit if available, useful to reconstruct a visitor flow across multiple pages.
+
+> Note: `parentHit` does not identify users, it only links anonymous visits together. It is designed to remain GDPR-compliant when used properly.
 
 ## 🔁 Listen to PageCallTrackedEvent
 

--- a/assets/dist/tracking_controller.js
+++ b/assets/dist/tracking_controller.js
@@ -6,6 +6,8 @@ export default class extends Controller {
 
         const params = new URLSearchParams(window.location.search);
 
+        const previousHitId = sessionStorage.getItem('page-call-hit-id');
+
         const payload = {
             url: url,
             route: this.element.dataset.route || null,
@@ -20,6 +22,7 @@ export default class extends Controller {
                 width: window.screen.width,
                 height: window.screen.height
             },
+            parentHitId: previousHitId ? parseInt(previousHitId) : null,
         };
 
         fetch('/zhortein/seo-tracking/page-call/track', {

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhortein/seo-tracking-bundle",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "symfony": {
     "controllers": {
       "tracking": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "description": "This bundle is dedicated to Symfony applications and provide metrics gathering on page calls.",
   "homepage": "https://www.david-renard.fr",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "authors": [
     {
       "name": "David Renard",

--- a/src/Entity/PageCallHit.php
+++ b/src/Entity/PageCallHit.php
@@ -45,6 +45,10 @@ class PageCallHit
     #[ORM\Column(nullable: true)]
     private ?int $screenHeight = null;
 
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    #[ORM\JoinColumn(name: 'parent_hit_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?self $parentHit = null;
+
     public function updateDuration(): void
     {
         if ($this->calledAt && $this->exitedAt) {
@@ -173,6 +177,18 @@ class PageCallHit
     public function setScreenHeight(?int $screenHeight): static
     {
         $this->screenHeight = $screenHeight;
+
+        return $this;
+    }
+
+    public function getParentHit(): ?self
+    {
+        return $this->parentHit;
+    }
+
+    public function setParentHit(?self $parentHit): static
+    {
+        $this->parentHit = $parentHit;
 
         return $this;
     }


### PR DESCRIPTION
> ⚠️ **This version needs to create a Doctrine migration**

### ✨ Added
- **Support for parentHit** in `PageCallHit`: you can now associate a hit with a parent hit to track navigation flows.
- Error handling and validation for `/track` and `/exit` endpoints (invalid JSON, missing URL or hitId, etc.).
- File `FEATURE_IDEAS.md` added to track suggestions and ideas.
- File `CONTRIBUTING.md` added for contributors.
- File `CHANGELOG.md` added.

### 📦 Changed
- Minor internal optimizations in the controller (reuse of `$em` instead of injecting repositories).
