### PR TITLE
new fields in `PageCall` and `PageCallHit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [1.2.0] – 2025-07-01
+
+> ⚠️ **This version requires a Doctrine migration** (new fields in `PageCall` and `PageCallHit`)
+
+### ✨ Added
+- Field `bot` in `PageCall`: detects and flags bot-related traffic.
+- Fields in `PageCallHit`:
+    - `bot`: flags bot visits based on User-Agent and heuristics.
+    - `pageTitle`: stores the document title (provided by JS).
+    - `delaySincePreviousHit`: calculates delay (in seconds) since `parentHit` if available.
+    - `pageType`: stores an optional value representing the semantic type of the page (e.g. `home`, `form`, `contact`, etc.).
+- Fallback handling for Stimulus tracking controller using HTML `data-*` attributes and `Values API`.
+
+### 🧰 Developer Experience
+- Updated README.md with new examples, shields, and clearer usage instructions.
+- Improved exception handling in Stimulus controller.
+- Added JS fallback in case of execution errors to ensure graceful degradation.
+
+---
+
 ## [1.1.0] – 2025-07-01
 
 > ⚠️ **This version needs to create a Doctrine migration**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-# seo-tracking-bundle
+# SEO Tracking Bundle
 Symfony bundle to track page views, UTM campaigns and basic engagement, with optional SEO insights integration.
+
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/zhortein/seo-tracking-bundle.svg)](https://packagist.org/packages/zhortein/seo-tracking-bundle)
+[![Total Downloads](https://img.shields.io/packagist/dt/zhortein/seo-tracking-bundle.svg)](https://packagist.org/packages/zhortein/seo-tracking-bundle)
+[![License](https://img.shields.io/packagist/l/zhortein/seo-tracking-bundle.svg)](https://github.com/Zhortein/seo-tracking-bundle/blob/main/LICENSE)
 
 ## 📦 Installation
 
@@ -25,16 +29,21 @@ php bin/console doctrine:migrations:migrate
 If you're using custom naming strategies or a prefixed schema, review the generated migration before applying it.
 
 ## ⚙️ Usage
-To enable tracking, include the Stimulus controller in your layout or any page you want to track:
+To enable tracking, include the [Stimulus](https://stimulus.hotwired.dev/) controller in your layout or any page you want to track.
 
+Add the following to your `<body>` tag to enable tracking:
 ```twig
 <body {{ stimulus_controller('zhortein--seo-tracking-bundle--tracking', {
         route: app.request.attributes.get('_route'),
-        routeArgs: app.request.attributes.get('_route_params')
-    }) }}
+        routeArgs: app.request.attributes.get('_route_params'),
+        type: 'home'
+    }) }}>
 ```
 
 We recommend placing the tracking call as early as possible in your page. The ```<body>``` tag is a good place for this.
+
+The `type` value is optional and allows you to define the nature of the page (e.g. `home`, `contact`, `form`, etc.).  
+This helps categorize traffic for SEO or UX analytics purposes.
 
 ## 🧠 What does this bundle track?
 
@@ -66,8 +75,11 @@ Tracked data includes:
 
 ## 📐 Data model overview
 
+> PageCall groups traffic based on UTM parameters and URL.  
+> PageCallHit represents each individual visit or hit within that group.
+
 ### PageCall
-This entity store Page calls grouped by their UTM values, with counting calls. It's related to a collection of hits.
+This entity stores Page calls grouped by their UTM values, with counting calls. It's related to a collection of hits.
 
 * url: URL called
 * route: Symfony route called
@@ -81,13 +93,14 @@ This entity store Page calls grouped by their UTM values, with counting calls. I
 * lastCalledAt: datetime of the last call
 * firstCalledAt: datetime of the first call
 * hits: related PageCallHits (see below)
+* bot: true if this call was made by a bot
 
 ### PageCallHit
 This entity stores information related to a visit (hit) and is related to a PageCall:
 
 * pageCall: related PageCall
 * referrer: URL of the referrer
-* userAgent: received USer Agent, raw format
+* userAgent: received User Agent, raw format
 * anonymizedIP: IP address of the visitor anonymized (GDPR compliance)
 * calledAt: datetime of the call
 * exitedAt: datetime of page exit
@@ -95,7 +108,11 @@ This entity stores information related to a visit (hit) and is related to a Page
 * language: navigator language (if provided by the navigator)
 * screenWidth: screen width in pixels (if provided by the navigator)
 * screenHeight: screen height in pixels (if provided by the navigator)
-* parentHit: previous PageCalledHit if available, useful to reconstruct a visitor flow across multiple pages.
+* parentHit: previous PageCallHit if available, useful to reconstruct a visitor flow across multiple pages.
+* bot: true if the hit was made by a bot.
+* pageTitle: page title, if provided.
+* delaySincePreviousHit: delay in seconds between current hit and its parent.
+* pageType: page data type, if provided.
 
 > Note: `parentHit` does not identify users, it only links anonymous visits together. It is designed to remain GDPR-compliant when used properly.
 

--- a/assets/dist/tracking_controller.js
+++ b/assets/dist/tracking_controller.js
@@ -53,7 +53,7 @@ export default class extends Controller {
 
     disconnect() {
         document.removeEventListener('visibilitychange', this.onVisibilityChange);
-
+    }
 
     onVisibilityChange = () => {
         if (document.visibilityState === 'hidden') {

--- a/assets/dist/tracking_controller.js
+++ b/assets/dist/tracking_controller.js
@@ -1,52 +1,69 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-    connect() {
-        const url = window.location.href;
-
-        const params = new URLSearchParams(window.location.search);
-
-        const previousHitId = sessionStorage.getItem('page-call-hit-id');
-
-        const payload = {
-            url: url,
-            route: this.element.dataset.route || null,
-            routeArgs: this.element.dataset.routeArgs ? JSON.parse(this.element.dataset.routeArgs) : null,
-            campaign: params.get('utm_campaign'),
-            medium: params.get('utm_medium'),
-            source: params.get('utm_source'),
-            term: params.get('utm_term'),
-            content: params.get('utm_content'),
-            language: navigator.language,
-            screen: {
-                width: window.screen.width,
-                height: window.screen.height
-            },
-            parentHitId: previousHitId ? parseInt(previousHitId) : null,
-        };
-
-        fetch('/zhortein/seo-tracking/page-call/track', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Requested-With': 'XMLHttpRequest'
-            },
-            body: JSON.stringify(payload),
-        })
-            .then(response => response.json())
-            .then(data => {
-                if (data.hitId) {
-                    sessionStorage.setItem('page-call-hit-id', data.hitId);
-                }
-            });
-
-        document.addEventListener('visibilitychange', () => {
-            if (document.visibilityState === 'hidden') {
-                const hitId = sessionStorage.getItem('page-call-hit-id');
-                if (hitId) {
-                    navigator.sendBeacon('/zhortein/seo-tracking/page-call/exit', JSON.stringify({ hitId }));
-                }
-            }
-        });
+    static values = {
+        type: { type: String, default: 'generic' },
     }
+
+    connect() {
+        try {
+            const url = window.location.href;
+            const params = new URLSearchParams(window.location.search);
+            const previousHitId = sessionStorage.getItem('page-call-hit-id');
+
+            const payload = {
+                url: url,
+                route: this.element.dataset.route || null,
+                routeArgs: this.element.dataset.routeArgs ? JSON.parse(this.element.dataset.routeArgs) : null,
+                campaign: params.get('utm_campaign'),
+                medium: params.get('utm_medium'),
+                source: params.get('utm_source'),
+                term: params.get('utm_term'),
+                content: params.get('utm_content'),
+                language: navigator.language,
+                screen: {
+                    width: window.screen.width,
+                    height: window.screen.height
+                },
+                parentHitId: previousHitId ? parseInt(previousHitId) : null,
+                title: document.title,
+                type: this.typeValue,
+            };
+
+            fetch('/zhortein/seo-tracking/page-call/track', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
+                },
+                body: JSON.stringify(payload),
+            })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.hitId) {
+                        sessionStorage.setItem('page-call-hit-id', data.hitId);
+                    }
+                });
+
+            document.addEventListener('visibilitychange', this.onVisibilityChange);
+        } catch (e) {+
+            console.warn('Tracking error', e);
+        }
+    }
+
+    disconnect() {
+        document.removeEventListener('visibilitychange', this.onVisibilityChange);
+
+
+    onVisibilityChange = () => {
+        if (document.visibilityState === 'hidden') {
+            const hitId = sessionStorage.getItem('page-call-hit-id');
+            if (hitId) {
+                navigator.sendBeacon(
+                    '/zhortein/seo-tracking/page-call/exit',
+                    new Blob([JSON.stringify({ hitId })], { type: 'application/json' })
+                );
+            }
+        }
+    };
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhortein/seo-tracking-bundle",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "symfony": {
     "controllers": {
       "tracking": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "description": "This bundle is dedicated to Symfony applications and provide metrics gathering on page calls.",
   "homepage": "https://www.david-renard.fr",
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "authors": [
     {
       "name": "David Renard",

--- a/src/Entity/PageCall.php
+++ b/src/Entity/PageCall.php
@@ -10,9 +10,9 @@ use Zhortein\SeoTrackingBundle\Repository\PageCallRepository;
 
 #[ORM\Entity(repositoryClass: PageCallRepository::class)]
 #[ORM\Table(name: 'seo_page_call')]
-#[ORM\Index(name: 'seo_page_call_idx', columns: ['url', 'campaign', 'medium', 'source', 'term', 'content'])]
-#[ORM\UniqueConstraint(name: 'seo_page_call_uq', columns: ['url', 'campaign', 'medium', 'source', 'term', 'content'])]
-#[UniqueEntity(fields: ['url', 'campaign', 'medium', 'source', 'term', 'content'])]
+#[ORM\Index(name: 'seo_page_call_idx', columns: ['url', 'campaign', 'medium', 'source', 'term', 'content', 'bot'])]
+#[ORM\UniqueConstraint(name: 'seo_page_call_uq', columns: ['url', 'campaign', 'medium', 'source', 'term', 'content', 'bot'])]
+#[UniqueEntity(fields: ['url', 'campaign', 'medium', 'source', 'term', 'content', 'bot'])]
 class PageCall
 {
     #[ORM\Id]
@@ -58,6 +58,9 @@ class PageCall
      */
     #[ORM\OneToMany(targetEntity: PageCallHit::class, mappedBy: 'pageCall', orphanRemoval: true)]
     private Collection $hits;
+
+    #[ORM\Column(options: ['default' => false])]
+    private bool $bot = false;
 
     public function __construct()
     {
@@ -229,5 +232,15 @@ class PageCall
         }
 
         return $this;
+    }
+
+    public function isBot(): bool
+    {
+        return $this->bot;
+    }
+
+    public function setBot(bool $bot): static
+    {
+        $this->bot = $bot;
     }
 }

--- a/src/Entity/PageCall.php
+++ b/src/Entity/PageCall.php
@@ -242,5 +242,6 @@ class PageCall
     public function setBot(bool $bot): static
     {
         $this->bot = $bot;
+        return $this;
     }
 }

--- a/src/Entity/PageCallHit.php
+++ b/src/Entity/PageCallHit.php
@@ -52,7 +52,7 @@ class PageCallHit
     #[ORM\Column(options: ['default' => false])]
     private bool $bot = false;
 
-    #[ORM\Column]
+    #[ORM\Column(nullable: true)]
     private ?int $delaySincePreviousHit = null;
 
     #[ORM\Column]

--- a/src/Entity/PageCallHit.php
+++ b/src/Entity/PageCallHit.php
@@ -68,7 +68,8 @@ class PageCallHit
         }
 
         if (null !== $this->parentHit && $this->parentHit->getCalledAt() && $this->calledAt) {
-            $this->delaySincePreviousHit = $this->parentHit->getCalledAt()->getTimestamp() - $this->calledAt->getTimestamp();
+            $delay = $this->calledAt->getTimestamp() - $this->parentHit->getCalledAt()->getTimestamp();
+            $this->delaySincePreviousHit = max(0, $delay);
         }
     }
 

--- a/src/Entity/PageCallHit.php
+++ b/src/Entity/PageCallHit.php
@@ -49,10 +49,26 @@ class PageCallHit
     #[ORM\JoinColumn(name: 'parent_hit_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?self $parentHit = null;
 
+    #[ORM\Column(options: ['default' => false])]
+    private bool $bot = false;
+
+    #[ORM\Column]
+    private ?int $delaySincePreviousHit = null;
+
+    #[ORM\Column]
+    private ?string $pageTitle = null;
+
+    #[ORM\Column]
+    private ?string $pageType = null;
+
     public function updateDuration(): void
     {
         if ($this->calledAt && $this->exitedAt) {
             $this->durationSeconds = $this->exitedAt->getTimestamp() - $this->calledAt->getTimestamp();
+        }
+
+        if (null !== $this->parentHit && $this->parentHit->getCalledAt() && $this->calledAt) {
+            $this->delaySincePreviousHit = $this->parentHit->getCalledAt()->getTimestamp() - $this->calledAt->getTimestamp();
         }
     }
 
@@ -192,4 +208,48 @@ class PageCallHit
 
         return $this;
     }
+
+    public function isBot(): bool
+    {
+        return $this->bot;
+    }
+
+    public function setBot(bool $bot): static
+    {
+        $this->bot = $bot;
+    }
+
+    public function getDelaySincePreviousHit(): ?int
+    {
+        return $this->delaySincePreviousHit;
+    }
+
+    public function setDelaySincePreviousHit(?int $delaySincePreviousHit): static
+    {
+        $this->delaySincePreviousHit = $delaySincePreviousHit;
+        return $this;
+    }
+
+    public function getPageTitle(): ?string
+    {
+        return $this->pageTitle;
+    }
+
+    public function setPageTitle(?string $pageTitle): static
+    {
+        $this->pageTitle = $pageTitle;
+        return $this;
+    }
+
+    public function getPageType(): ?string
+    {
+        return $this->pageType;
+    }
+
+    public function setPageType(?string $pageType): static
+    {
+        $this->pageType = $pageType;
+        return $this;
+    }
+
 }

--- a/src/Entity/PageCallHit.php
+++ b/src/Entity/PageCallHit.php
@@ -55,10 +55,10 @@ class PageCallHit
     #[ORM\Column(nullable: true)]
     private ?int $delaySincePreviousHit = null;
 
-    #[ORM\Column]
+    #[ORM\Column(nullable: true)]
     private ?string $pageTitle = null;
 
-    #[ORM\Column]
+    #[ORM\Column(nullable: true)]
     private ?string $pageType = null;
 
     public function updateDuration(): void

--- a/src/Entity/PageCallHit.php
+++ b/src/Entity/PageCallHit.php
@@ -217,6 +217,7 @@ class PageCallHit
     public function setBot(bool $bot): static
     {
         $this->bot = $bot;
+        return $this;
     }
 
     public function getDelaySincePreviousHit(): ?int


### PR DESCRIPTION
## [1.2.0] – 2025-07-01

> ⚠️ **This version requires a Doctrine migration** (new fields in `PageCall` and `PageCallHit`)

### ✨ Added
- Field `bot` in `PageCall`: detects and flags bot-related traffic.
- Fields in `PageCallHit`:
    - `bot`: flags bot visits based on User-Agent and heuristics.
    - `pageTitle`: stores the document title (provided by JS).
    - `delaySincePreviousHit`: calculates delay (in seconds) since `parentHit` if available.
    - `pageType`: stores an optional value representing the semantic type of the page (e.g. `home`, `form`, `contact`, etc.).
- Fallback handling for Stimulus tracking controller using HTML `data-*` attributes and `Values API`.

### 🧰 Developer Experience
- Updated README.md with new examples, shields, and clearer usage instructions.
- Improved exception handling in Stimulus controller.
- Added JS fallback in case of execution errors to ensure graceful degradation.
